### PR TITLE
Update of "calculateTime()" function

### DIFF
--- a/firmware/nixie_clock_v1.3/nixie_clock_v1.3.ino
+++ b/firmware/nixie_clock_v1.3/nixie_clock_v1.3.ino
@@ -335,6 +335,12 @@ void calculateTime() {
         mins = now.minute();
         hrs = now.hour();
       }
+      if (mins > 59) {
+        mins = 0;
+        hrs++;
+        if (hrs > 23) hrs = 0;
+        changeBright();
+      }
 
       if (!alm_flag && alm_mins == mins && alm_hrs == hrs && !digitalRead(ALARM)) {
         mode = 0;
@@ -342,19 +348,6 @@ void calculateTime() {
         almTimer.start();
         almTimer.reset();
       }
-    }
-    if (mins > 59) {
-      mins = 0;
-      hrs++;
-      if (hrs > 23) hrs = 0;
-      changeBright();
-    }
-
-    if (!alm_flag && alm_mins == mins && alm_hrs == hrs && !digitalRead(ALARM)) {
-      mode = 0;
-      alm_flag = true;
-      almTimer.start();
-      almTimer.reset();
     }
 
     if (mode == 0) sendTime();

--- a/firmware/nixie_clock_v1.3/nixie_clock_v1.3.ino
+++ b/firmware/nixie_clock_v1.3/nixie_clock_v1.3.ino
@@ -350,6 +350,12 @@ void calculateTime() {
       changeBright();
     }
 
+    if (!alm_flag && alm_mins == mins && alm_hrs == hrs && !digitalRead(ALARM)) {
+      mode = 0;
+      alm_flag = true;
+      almTimer.start();
+      almTimer.reset();
+    }
 
     if (mode == 0) sendTime();
 


### PR DESCRIPTION
Impracticable condition for an alarm set to time multiple to hours.
For example, alarm set to 09:00. Current time is 08:59:59. Condition "alm_mins == mins" is checked only if "sec>59". Mins become equal to 60 right after checking "sec>59". So, the time now is 08:60:00. After this "alarm condition" is checked. It is not satisfied. Only after all, mins are set to 00 and hours are updated. Time is 08:00:00. Alarm condition won't be checked.